### PR TITLE
Use `primer-markdown.css` as build file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can also import specific portions of the module by importing those partials 
 
 ## Build
 
-For a compiled **css** version of this module, a npm script is included that will output a css version to `build/build.css` The built css file is also included in the npm package.
+For a compiled **css** version of this module, a npm script is included that will output a css version to `build/primer-markdown.css` The built css file is also included in the npm package.
 
 ```
 $ npm run build

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "setup": "if [ ! -d \"node_modules\" ]; then npm install; fi",
-    "build": "node-sass index.scss --include-path node_modules --output-style compressed | postcss -c .postcss.json -o build/build.css",
+    "build": "node-sass index.scss --include-path node_modules --output-style compressed | postcss -c .postcss.json -o build/primer-markdown.css",
     "prepublish": "npm run setup && npm run build",
     "test": "npm run build && stylelint **/*.scss -c .stylelintrc.json -s scss"
   },


### PR DESCRIPTION
The current `build/build.css` file name is quite generic.
It would be clearer to name the dist file `primer-markdown.css`, so it is clearer when it's used (in HTML) what the file does/ where it's from.