### PR TITLE
Fix extra fancy code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,13 @@ Code snippets like `var foo = "bar";` can be shown inline.
 Also, `this should vertically align` ~~`with this`~~ ~~and this~~.
 
 Code can also be shown in a block element.
+
 ```
 var foo = "bar";
 ```
 
 Code can also use syntax highlighting.
+
 ```javascript
 var foo = "bar";
 ```

--- a/README.md
+++ b/README.md
@@ -168,20 +168,20 @@ Code snippets like `var foo = "bar";` can be shown inline.
 Also, `this should vertically align` ~~`with this`~~ ~~and this~~.
 
 Code can also be shown in a block element.
-````
+```
 var foo = "bar";
-````
+```
 
 Code can also use syntax highlighting.
-````Javascript
+```javascript
 var foo = "bar";
-````
+```
 
 ```
 Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.
 ```
 
-```Javascript
+```javascript
 var foo = "The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.";
 ```
 


### PR DESCRIPTION
:wave: 

I'm pretty sure there is an extra backtick somewhere in your readme.

Also I think the preferred way to specify the syntax highlighting is in lower case.

Source: https://guides.github.com/features/mastering-markdown/ ?